### PR TITLE
Remove :mode specification for protobuf-mode

### DIFF
--- a/emacs/features/protobuf.el
+++ b/emacs/features/protobuf.el
@@ -1,6 +1,5 @@
 (use-package protobuf-mode
   :ensure t
-  :mode (("\\.proto\\'" . protobuf-mode))
   :hook ((protobuf-mode . goto-address-prog-mode))
   :config
   (defun ar/reindex-proto-fields ()


### PR DESCRIPTION
".proto" files are already handled by protobuf-mode.

https://github.com/protocolbuffers/protobuf/blob/0038ff49af882463c2af9049356eed7df45c3e8e/editors/protobuf-mode.el#L193